### PR TITLE
Handle text responses when servers.json missing

### DIFF
--- a/app/api/[...slug]/route.ts
+++ b/app/api/[...slug]/route.ts
@@ -42,11 +42,11 @@ async function handler(req: NextRequest) {
       }
 
       const contentType = apiRes.headers.get("content-type") || ""
-      if (contentType.includes("text/plain")) {
+      if (contentType.startsWith("text/")) {
         const text = await apiRes.text()
         return new Response(text, {
           status: apiRes.status,
-          headers: { "Content-Type": "text/plain" },
+          headers: { "Content-Type": contentType },
         })
       }
 

--- a/app/deploy/page.tsx
+++ b/app/deploy/page.tsx
@@ -44,12 +44,19 @@ export default function DeployPage() {
     const fetchServers = async () => {
       try {
         const res = await fetch("/api/servers")
-        if (!res.ok) {
-          const errorData = await res.json()
-          throw new Error(errorData.detail || "Failed to fetch servers")
+        const text = await res.text()
+        let parsed: any
+        try {
+          parsed = JSON.parse(text)
+        } catch {
+          throw new Error(text || "Invalid response from server")
         }
-        const data = await res.json()
-        setServers(data)
+
+        if (!res.ok) {
+          throw new Error(parsed.detail || "Failed to fetch servers")
+        }
+
+        setServers(parsed)
       } catch (err: any) {
         setError(err.message)
       } finally {


### PR DESCRIPTION
## Summary
- relax API proxy to pass through any text/* responses
- parse server list response as text first so invalid JSON doesn't crash the UI

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68776e513420832db5d0d208cf323e58