### PR TITLE
Fix README to mention FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A full-stack application to trigger and monitor deployments.
 ## Struktur
 
 - **`app/`**: Next.js frontend (Pages Router) untuk antarmuka pengguna.
-- **`backend/`**: Aplikasi Flask (Python) sebagai API backend.
+- **`backend/`**: Aplikasi FastAPI (Python) sebagai API backend.
 - **`docker-compose.yml`**: Orkestrasi frontend dan backend.
 - **`deploy.sh`**: Skrip deployment yang dijalankan backend.
 - **`servers.json`**: Daftar server tujuan deploy.


### PR DESCRIPTION
## Summary
- update README to reference a FastAPI backend instead of Flask

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm install` *(fails: Forbidden 403 when fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6878a13700d8832daf2f1823ea8f6123